### PR TITLE
Add packages installed by napa to dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ module.exports = function (options){
         options.packageJsonPath = path.join(path.dirname(caller.filePath), options.packageJsonPath);
     }
 
+    for (key in packages.napa) {
+        packages.dependencies[key] = packages.dependencies[key] || packages.napa[key]
+    }
     for (key in packages.dependencies) {
         override = overrides[key] || {};
         keys = keys.concat(getMainFiles(options.nodeModulesPath + "/" + key, override));


### PR DESCRIPTION
Npmfiles see only dependencies and devDependencies in package.json.
However, packages installed by napa are defined in "napa". So mainNPMFiles does not get them.
I tried to add napa packages to dependencies for getting them by mainNPMFiles.